### PR TITLE
Added new admin path, added logo to admin page.

### DIFF
--- a/src/components/admin/AdminEventList.vue
+++ b/src/components/admin/AdminEventList.vue
@@ -59,6 +59,13 @@ export default class AdminEventList extends Vue {
 </script>
 
 <style scoped>
+.container {
+  margin-top: 22px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  width: 30em;
+}
 table {
   table-layout: fixed;
   border-collapse: collapse;

--- a/src/components/admin/AdminEvents.vue
+++ b/src/components/admin/AdminEvents.vue
@@ -94,7 +94,6 @@ export default class AdminEvents extends Vue {
 
 <style scoped>
 .container {
-  margin-top: 22px;
   display: flex;
   flex-direction: column;
   align-items: flex-start;

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -31,13 +31,13 @@ const routes: RouteConfig[] = [
         beforeEnter: signinSilentCallbackGuard
       },
       {
-        path: 'admin/signin',
+        path: 'authadmin/signin',
         name: 'signin',
         component: SignInView
       },
       {
-        path: 'admin',
-        name: 'admin',
+        path: 'authadmin',
+        name: 'authadmin',
         component: AdminView,
         children: [
           {
@@ -49,6 +49,11 @@ const routes: RouteConfig[] = [
             } // Or component like below,
           }
         ]
+      },
+      {
+        path: 'admin',
+        name: 'admin',
+        component: AdminView,
       },
       {
         path: 'event',

--- a/src/views/AdminView.vue
+++ b/src/views/AdminView.vue
@@ -1,9 +1,12 @@
 <template>
-  <div>
+  <div class="admin-container">
+    <img id="logo" src="../assets/app-logo.svg" />
+    <!-- Remove comment when reintroducing authentication
     <user />
     <button @click="signOut">Sign Out</button>
-
+    -->
     <!-- All subroutes within this component will only be shown if the user is authenticated -->
+    <admin-events />
     <router-view />
   </div>
 </template>
@@ -13,13 +16,16 @@ import { Vue, Component } from 'vue-property-decorator';
 
 import { signOut, isAuthenticated } from '@/services/authentication.service';
 import User from '@/components/Admin/User.vue';
+import AdminEvents from '@/components/Admin/AdminEvents.vue';
 
 @Component({
   components: {
-    User
+    User,
+    AdminEvents
   }
 })
 export default class AdminView extends Vue {
+  /* Remove comment when reintroducing authentication
   private signOut = signOut;
 
   private async created() {
@@ -35,8 +41,17 @@ export default class AdminView extends Vue {
       this.$router.push({ name: 'signin' });
     }
   }
+  */
 }
 </script>
 
 <style scoped>
+.admin-container {
+  display: inline-block;
+}
+
+#logo {
+  position: relative;
+  bottom: 3em;
+}
 </style>


### PR DESCRIPTION
- New admin path called 'admin'
- Previous authenticated admin path now called: 'authadmin'
- Updated AdminView to contain logo, and AdminEvents component, and commented out authentication stuff.
- Fixed one css issue where margin between logo and AdminEvents component was to large.